### PR TITLE
TRT-700: Sort keys in JSON output files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.1] - 2025-08-14
+
+### Changed
+
+- Keys in JSON output files are now sorted alphabetically. This does not affect
+  comparisons against JSON files that are not alphabetically sorted, as the
+  comparison first checks the sets of keys in both files, and then ensures that
+  the value assigned to the same key in both files are the same. Neither of
+  these operations are dependent on the key ordering in the file itself. This
+  does, however, prepare the way for future functionality to display the
+  difference between two files with different hash values.
+
 ## [v1.0.0] - 2025-07-22
 
 ### Added
@@ -16,4 +28,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pre-commit CI/CD checks, including mypy and ruff.
 - CI/CD workflows as GitHub actions.
 
+[v1.0.1]: https://github.com/nasa/earthdata-hashdiff/releases/tag/1.0.1
 [v1.0.0]: https://github.com/nasa/earthdata-hashdiff/releases/tag/1.0.0

--- a/earthdata_hashdiff/__about__.py
+++ b/earthdata_hashdiff/__about__.py
@@ -1,3 +1,3 @@
 """Version for the package - only edit when intending to release."""
 
-version = '1.0.0'
+version = '1.0.1'

--- a/earthdata_hashdiff/generate.py
+++ b/earthdata_hashdiff/generate.py
@@ -113,7 +113,7 @@ def get_hashes_from_xarray_input(
 def write_reference_file(reference_file_path: str, hash_output: dict[str, str]):
     """Write JSON containing SHA256 hashes to an output file."""
     with open(reference_file_path, 'w', encoding='utf-8') as file_handler:
-        json.dump(hash_output, file_handler, indent=2)
+        json.dump(hash_output, file_handler, indent=2, sort_keys=True)
 
 
 def get_hash_of_xarray_dataset(


### PR DESCRIPTION
## Description

This PR updates the output in JSON files to order keys alphabetically. It can be seen to not impact existing reference files, as the test fixtures in `tests/conftest.py` have some keys that are non-alphabetically ordered, and those tests still pass.

## Jira Issue ID

TRT-700

## Local Test Steps

(If you are feeling fastidious)

* Pull this branch.
* Activate a conda/mamba environment for one of the regression test suites that uses a reference file.
* `pip install -e .` this version of the package.
* Run the regression test suite notebook using this package (likely running the notebook via a browser, rather than in a Docker image, to ensure you are using the locally installed version of `earthdata-hashdiff`).
* The tests should still pass. 🎉 

## PR Acceptance Checklist
* ~~Acceptance criteria met~~ (Quality of life tweak)
* [x] Tests added/updated (if needed) and passing (tests passing, but no changes necessary)
* ~~Documentation updated (if needed)~~
* [x] CHANGELOG updated with the changes for this PR
* [x] Package's `__about__.py` file changed if a new version should be published.