### PR TITLE
TRT-701: Add documentation notebook.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ dmypy.json
 
 # hatch
 dist/*
+
+# Documentation ancillary files
+docs/*json
+docs/*HDF5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # earthdata-hashdiff
 
+[![Available on pypi](https://img.shields.io/pypi/v/earthdata-hashdiff.svg)](https://pypi.python.org/pypi/earthdata-hashdiff/)
+
 This repository contains functionality to read Earth science data file formats
 and hash the contents of those files into a JSON object. This enables the easy
 storage of a smaller artefact for tasks such as regression tests, while omitting

--- a/docs/Using_earthdata-hashdiff.ipynb
+++ b/docs/Using_earthdata-hashdiff.ipynb
@@ -1,0 +1,444 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2fb338e8-e86a-4443-95e2-d19b6b4f45dc",
+   "metadata": {},
+   "source": [
+    "# earthdata-hashdiff\n",
+    "\n",
+    "**Contact:** Owen Littlejohns (owen.m.littlejohns@nasa.gov)\n",
+    "\n",
+    "This notebook will demonstrate typical workflows to use the [earthdata-hashdiff](https://github.com/nasa/earthdata-hashdiff) Python package.\n",
+    "\n",
+    "## What is earthdata-hashdiff?\n",
+    "\n",
+    "`earthdata-hashdiff` is a Python package that parses Earth science data file formats (HDF-5 and netCDF4) and hashes the contents of those files. These hashes are stored in a JSON object, which can be saved to disk. This enables the easy storage of a smaller artefact for tasks such as regression testing, while omitting metadata and data attributes that may change between test executions (such as timestamps in history attributes). The package also allows for comparison between a binary file (HDF-5 or netCDF4) and a JSON file containing previously calculated hashes.\n",
+    "\n",
+    "## earthdata-hashdiff installation:\n",
+    "\n",
+    "`earthdata-hashdiff` can be installed via pip using the standard command: `pip install earthdata-hashdiff`.\n",
+    "\n",
+    "## Running this notebook:\n",
+    "\n",
+    "First create a Python environment to allow for isolated installation of Python packages using either pyenv or conda. If using conda, run the following commands from within the `docs` directory:\n",
+    "\n",
+    "```\n",
+    "# Create the new conda environment:\n",
+    "conda create --name earthdata-hashdiff-docs python=3.12 -c conda-forge --override-channels -y\n",
+    "\n",
+    "# Activate the environment:\n",
+    "conda activate earthdata-hashdiff-docs\n",
+    "\n",
+    "# Install necessary packages:\n",
+    "pip install -r requirements.txt\n",
+    "```\n",
+    "\n",
+    "## Downloading sample data:\n",
+    "\n",
+    "This notebook will use sample data from the Global Precipitation Monitor (GPM) Integrated Multi-satellitE Retrievals for GPM (IMERG) Final Precipitation data (half hourly, 0.1 degree spatial resolution). To be able to execute this notebook, use the links below to download two sample files:\n",
+    "\n",
+    "* [3B-HHR.MS.MRG.3IMERG.20250331-S220000-E222959.1320.V07B.HDF5](https://data.gesdisc.earthdata.nasa.gov/data/GPM_L3/GPM_3IMERGHH.07/2025/090/3B-HHR.MS.MRG.3IMERG.20250331-S220000-E222959.1320.V07B.HDF5)\n",
+    "* [3B-HHR.MS.MRG.3IMERG.20250331-S223000-E225959.1350.V07B.HDF5](https://data.gesdisc.earthdata.nasa.gov/data/GPM_L3/GPM_3IMERGHH.07/2025/090/3B-HHR.MS.MRG.3IMERG.20250331-S223000-E225959.1350.V07B.HDF5)\n",
+    "\n",
+    "The notebook will assume that these two files are present in the `docs` directory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b53cd57-2252-4fe9-8096-a04634c29b8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gpm_3imerghh_granule_one = (\n",
+    "    '3B-HHR.MS.MRG.3IMERG.20250331-S220000-E222959.1320.V07B.HDF5'\n",
+    ")\n",
+    "gpm_3imerghh_granule_two = (\n",
+    "    '3B-HHR.MS.MRG.3IMERG.20250331-S223000-E225959.1350.V07B.HDF5'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0672e071-71bc-4064-9753-b269b92a332b",
+   "metadata": {},
+   "source": [
+    "## Generating hashes:\n",
+    "\n",
+    "`earthdata-hashdiff` has 2 public methods for generating JSON structures containing hashes of variables and groups within an HDF-5 or netCDF4 file: `create_nc4_hash_file` and `create_h5_hash_file`. Both work in an identical way (and are, infact, aliases to the same underlying function).\n",
+    "\n",
+    "To begin, the function must be imported from the package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "febe010d-71c1-460d-ad15-4a310e48f012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from earthdata_hashdiff import create_h5_hash_file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "946e3377-51df-41ac-a506-2fd48c508db9",
+   "metadata": {},
+   "source": [
+    "Now a JSON file can be produced. The command below will create a JSON file: `3B-HHR.MS.MRG.3IMERG.20250331-S220000-E222959.1320.V07B.HDF5.json`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0051953-1cc7-4699-9f0d-2409a4181457",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_h5_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.json',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "708a8828-f848-452a-8fd3-2535fa66b884",
+   "metadata": {},
+   "source": [
+    "The output from this function is displayed below. The JSON file contains a dictionary of key/value pairs, where the keys are full paths within the file to the group or variable being hashed, and the value is the SHA256 hash for that group or variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36493c53-022e-4e67-af36-aa5262dd5538",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "with open(f'{gpm_3imerghh_granule_one}.json') as file_handler:\n",
+    "    gpm_3imerghh_granule_one_hashes = json.load(file_handler)\n",
+    "\n",
+    "print(json.dumps(gpm_3imerghh_granule_one_hashes, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8614ba16-31d9-4bc4-b0b4-e59cbc4c4ea6",
+   "metadata": {},
+   "source": [
+    "The information that is considered when generating the hash value is:\n",
+    "\n",
+    "* Metadata attributes on the group or variable (excluding `history` and `history_json` metadata attributes).\n",
+    "* Dimensions for that group or variable.\n",
+    "* (Variable only) the shape and elements of the data array.\n",
+    "\n",
+    "To demonstrate this, the second GPM_3IMERGHH granule can also be used to generate a JSON file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fc1a66dc-4e39-4142-991a-b10fcecf70d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_h5_hash_file(\n",
+    "    gpm_3imerghh_granule_two,\n",
+    "    f'{gpm_3imerghh_granule_two}.json',\n",
+    ")\n",
+    "\n",
+    "with open(f'{gpm_3imerghh_granule_two}.json') as file_handler:\n",
+    "    gpm_3imerghh_granule_two_hashes = json.load(file_handler)\n",
+    "\n",
+    "print(json.dumps(gpm_3imerghh_granule_two_hashes, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebfb13b9-9984-4e38-be31-425fa5b52686",
+   "metadata": {},
+   "source": [
+    "Comparisons between the hashes for the two files show that some of them are the same:\n",
+    "\n",
+    "* `/Grid`\n",
+    "* `/Grid/Intermediate`\n",
+    "* `/Grid/lat`\n",
+    "* `/Grid/lat_bnds`\n",
+    "* `/Grid/lon`\n",
+    "* `/Grid/lon_bnds`\n",
+    "\n",
+    "These groups and variables are the same in both granules. They represent either groups that are primarily present to offer structure to the granule hierarchy, or the whole-Earth spatial dimensions that are the same for all GPM_3IMERGHH granules.\n",
+    "\n",
+    "The other variables differ due to containing different values in their arrays, due to the different time over which the measurements were taken.\n",
+    "\n",
+    "### Additional options for generating hashes:\n",
+    "\n",
+    "There are two additional kwargs that can be specified when generating hashes from a file:\n",
+    "\n",
+    "* `skipped_metadata_attributes` - this is a set of strings that represent the names of metadata attributes to not include in the calculation of hashes (for all groups and variables). By default `history` and `history_json` are already omitted as they may vary due to transformation operations being applied at different times (e.g., in Harmony regression tests). However, some files may have additional metadata attributes due to on-demand processing with values that will vary based on execution times. Those should also be excluded from the generated hash via this kwarg.\n",
+    "* `xarray_kwargs` - `earthdata-hashdiff` uses `xarray` to read HDF-5 and netCDF4 files, and this dictionary allows control of how `xarray` opens a file. For example, whether times, timedeltas, coordinates or CF Conventions are decoded. The choice to decode, or not, these options will lead to different hashes. By default none of these items are decoded.\n",
+    "\n",
+    "### Example 1: Skipping metadata attributes:\n",
+    "\n",
+    "The example below will generate hashes for the first GPM_3IMERGHH granule, skipping the `GridHeader` metadata attribute in groups and variables. This attribute is only present on the `/Grid` group, and so this is the only hash that should be different:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf77c671-680a-4804-ada7-cc668bc01ab4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_h5_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.skip.json',\n",
+    "    skipped_metadata_attributes={'GridHeader'},\n",
+    ")\n",
+    "\n",
+    "with open(f'{gpm_3imerghh_granule_one}.skip.json') as file_handler:\n",
+    "    gpm_3imerghh_granule_one_skip_hashes = json.load(file_handler)\n",
+    "\n",
+    "print(json.dumps(gpm_3imerghh_granule_one_skip_hashes, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cf6b064-d510-44c9-84b7-455c3925a5f8",
+   "metadata": {},
+   "source": [
+    "### Example 2: Changing `xarray` defaults:\n",
+    "\n",
+    "This example will tell `xarray` to decode times when it opens the granule. As a result, the `/Grid/time` and `/Grid/time_bnds` variables will have different hashes, as the array elements will now be decoded into datetimes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d84b831-c425-4575-8c4a-e1844af60483",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_h5_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.decode.json',\n",
+    "    xarray_kwargs={\n",
+    "        'decode_cf': False,\n",
+    "        'decode_coords': False,\n",
+    "        'decode_timedelta': False,\n",
+    "        'decode_times': True,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "with open(f'{gpm_3imerghh_granule_one}.decode.json') as file_handler:\n",
+    "    gpm_3imerghh_granule_one_decode_hashes = json.load(file_handler)\n",
+    "\n",
+    "print(json.dumps(gpm_3imerghh_granule_one_decode_hashes, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "170873bf-39f2-4907-a9c9-78fe49dee330",
+   "metadata": {},
+   "source": [
+    "## Performing comparisons:\n",
+    "\n",
+    "This package also allows the comparison of a netCDF4 file to a JSON file containing previously calculated hash values. There are two functions to perform this, both with the same arguments: `nc4_matches_reference_hash_file` and `h5_matches_reference_hash_file`.\n",
+    "\n",
+    "These functions compare the following:\n",
+    "\n",
+    "* That the binary file and the JSON file containing hashes have the same variables and groups.\n",
+    "* That the hash values match for all variables and groups."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "850acd17-b96b-40c4-94f9-9e95478170ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from earthdata_hashdiff import h5_matches_reference_hash_file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e8c66ac-7852-46cf-845f-e4e1a387ab92",
+   "metadata": {},
+   "source": [
+    "These functions return a boolean value, and so are easily used in assertions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1de8d3e4-26ca-4e5d-9072-db3efccf5b03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert h5_matches_reference_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.json',\n",
+    "), 'Binary file did not match previously generated hashes.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8276063-7126-401b-8a8e-c745738275dd",
+   "metadata": {},
+   "source": [
+    "Comparing the first GPM_3IMERGHH file to the hashes calculated for the second file will show failure in the comparison:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "118273f7-c79d-4b2c-bbc3-11ed7a67f939",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert h5_matches_reference_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_two}.json',\n",
+    "), 'Binary file did not match previously generated hashes.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c542dab-ce46-4aa3-8bd4-03fdbc209227",
+   "metadata": {},
+   "source": [
+    "### Additional options for comparisons:\n",
+    "\n",
+    "There are three kwargs that can be used to refine the behaviour of the comparison functionality:\n",
+    "\n",
+    "* `skipped_variables_or_groups` - this set of strings instructs the comparison to not compare the hashes for the groups or variables listed. Note, the comparison will still confirm that all the same variables and groups were in the binary file and JSON file.\n",
+    "* `skipped_metadata_attributes` - this is a set of strings representing metadata attributes in the binary file that will not be used in the generation of hashes for variables or groups. If metadata attributes were specified to be skipped using this mechanism when generating the original JSON file used in the comparison, the same metadata attributes should be specified to be skipped in the comparison, too.\n",
+    "* `xarray_kwargs` - as with generation, this is a dictionary of kwargs used by `xarray` when opening the binary file being compared.\n",
+    "\n",
+    "### Example 3: skipping variables or groups:\n",
+    "\n",
+    "In example 2 for generating a hash file, the `xarray` option to decode times was enabled. This altered the hash values for `/Grid/time` and `/Grid/time_bnds`. As such, a comparison between the hash file from that example and the first GPM_3IMERGHH file, which uses the defaults for comparison, will fail:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27e704db-daad-4eae-abc9-234618dc59a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert h5_matches_reference_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.decode.json',\n",
+    "), 'Binary file did not match previously generated hashes.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90982ac0-fd3d-4e5b-8a82-505ca471f5ef",
+   "metadata": {},
+   "source": [
+    "However, the `/Grid/time` and `/Grid/time_bnds` variables can be omitted from the comparison, and the assertion will pass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d15c007-d034-4d16-9aa0-aa5162021729",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert h5_matches_reference_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.decode.json',\n",
+    "    skipped_variables_or_groups={'/Grid/time', '/Grid/time_bnds'},\n",
+    "), 'Binary file did not match previously generated hashes.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1b3f568-f441-45b5-9409-364328b5799c",
+   "metadata": {},
+   "source": [
+    "### Example 4: skipping metadata attributes:\n",
+    "\n",
+    "In example 1 for generating a hash file, the `GridHeader` metadata attribute was not included in the generation of hashes for groups and variables. This altered the hash value for `/Grid`. As such, a comparison between the hash file from that example and the first GPM_3IMERGHH file, which uses the defaults for comparison, will fail:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "638c3e80-2131-4861-83e5-a16a1607d487",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert h5_matches_reference_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.skip.json',\n",
+    "), 'Binary file did not match previously generated hashes.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd88de75-dda5-4b51-af7a-5c7a86a4d49f",
+   "metadata": {},
+   "source": [
+    "However, if the `GridHeader` attribute is omitted from the comparison, the assertion will pass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd67a1ef-8206-4469-a462-22f693ed9f6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert h5_matches_reference_hash_file(\n",
+    "    gpm_3imerghh_granule_one,\n",
+    "    f'{gpm_3imerghh_granule_one}.skip.json',\n",
+    "    skipped_metadata_attributes={'GridHeader'},\n",
+    "), 'Binary file did not match previously generated hashes.'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c61a5f43-2bf2-42f6-8c39-abeef381816f",
+   "metadata": {},
+   "source": [
+    "# Further questions?\n",
+    "\n",
+    "Feel free to reach out either:\n",
+    "\n",
+    "* Via a [GitHub issue](https://github.com/nasa/earthdata-hashdiff/issues)\n",
+    "* Via email: owen.m.littlejohns@nasa.gov\n",
+    "* Via the NASA Agency Slack (internal developers)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# These packages are required to run the documentation Jupyter notebook.
+earthdata-hashdiff ~= 1.0.1
+notebook ~= 7.4.5
+requests ~= 2.32.4


### PR DESCRIPTION
## Description

This PR adds documentation for how to use `earthdata-hashdiff`. This notebook will likely be the documentation I run through if/when there's a brownbag on how to use the package.

## Jira Issue ID

TRT-701

## Local Test Steps

* Pull this branch.
* Create a conda environment, then `pip install` the packages in `docs/requirements.txt`.
* Start a notebook server.
* Run through the notebook (note, some cells are designed to fail, so you can't just run them all in one go)

## PR Acceptance Checklist
* [x] Acceptance criteria met (the AC for creating documentation)
* ~~Tests added/updated (if needed) and passing~~
* [x] Documentation updated (if needed)
* ~~CHANGELOG updated with the changes for this PR~~ (not a release)
* ~~Package's `__about__.py` file changed if a new version should be published.~~ (not a release)