### PR TITLE
TRT-315: Append commit history to release notes.

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -22,7 +22,9 @@ jobs:
 
     steps:
       - name: Checkout earthdata-hashdiff repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout earthdata-hashdiff repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [vX.Y.Z] - Unreleased
+
+### Changed
+
+- Release notes published in GitHub should now also contain a list of commit
+  messages since the last release. These will omit commits from pre-commit-ci.
+
 ## [v1.1.0] - 2025-08-19
 
 ### Added
@@ -46,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pre-commit CI/CD checks, including mypy and ruff.
 - CI/CD workflows as GitHub actions.
 
+[v1.1.0]: https://github.com/nasa/earthdata-hashdiff/releases/tag/1.1.0
 [v1.0.2]: https://github.com/nasa/earthdata-hashdiff/releases/tag/1.0.2
 [v1.0.1]: https://github.com/nasa/earthdata-hashdiff/releases/tag/1.0.1
 [v1.0.0]: https://github.com/nasa/earthdata-hashdiff/releases/tag/1.0.0

--- a/bin/extract-release-notes.sh
+++ b/bin/extract-release-notes.sh
@@ -9,6 +9,7 @@
 # 2024-01-03: Copied from HOSS repository to the Swath Projector.
 # 2024-01-23: Copied and modified from Swath Projector repository to HyBIG.
 # 2025-07-15: Copied and modified from HyBIG to earthdata-hashdiff.
+# 2025-09-22: Append git commit messages to release notes.
 #
 ###############################################################################
 
@@ -28,5 +29,27 @@ LINK_PATTERN="^\[.*\]:.*https://github.com/nasa"
 # VERSION_PATTERN
 result=$(awk "/$VERSION_PATTERN/{c++; if(c==2) exit;} c==1" "$CHANGELOG_FILE")
 
+# Get all commit messages since the last release (marked with a git tag). If
+# there are no tags, get the full commit history of the repository.
+if [[ $(git tag) ]]
+then
+	# There are git tags, so get the most recent one
+	GIT_REF=$(git describe --tags --abbrev=0)
+else
+	# There are not git tags, so get the initial commit of the repository
+	GIT_REF=$(git rev-list --max-parents=0 HEAD)
+fi
+
+# Retrieve the title line of all commit messages since $GIT_REF, filtering out
+# those from the pre-commit-ci[bot] author and any containing the string
+# "nasa/pre-commit-ci-update-config", which may result from merge commits.
+GIT_COMMIT_MESSAGES=$(git log --oneline --format="%s" --perl-regexp --author='^(?!pre-commit-ci\[bot\]).*$' --grep="nasa\/pre-commit-ci-update-config" --invert-grep ${GIT_REF}..HEAD)
+
+# Append git commit messages to the release notes:
+if [[ ${GIT_COMMIT_MESSAGES} ]]
+then
+	result+="\n\n## Commits\n\n${GIT_COMMIT_MESSAGES}"
+fi
+
 # Print the result
-echo "$result" |  grep -v "$VERSION_PATTERN" | grep -v "$LINK_PATTERN"
+echo -e "$result" |  grep -v "$VERSION_PATTERN" | grep -v "$LINK_PATTERN"


### PR DESCRIPTION
## Description

This PR updates the generation of release notes to include the commit history for the release. This is in response to NSIDC wanting an easier way to map between releases and the work included in them.

I've also added a missing link from `CHANGELOG.md` for version 1.1.0.

## Jira Issue ID

TRT-315 (and other NSIDC verification related tickets)

## Local Test Steps

* Pull this branch.
* Run `bin/extract-release-notes.sh` to ensure the most recent release notes are extracted.

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* [x] `CHANGELOG.md` updated to include high level summary of PR changes.
* ~~`VERSION` updated if publishing a release.~~ (Just an update to CI/CD)
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~